### PR TITLE
Fix Framed Blocks conflict when other mods are present

### DIFF
--- a/src/main/java/ballistix/common/block/BlockExplosive.java
+++ b/src/main/java/ballistix/common/block/BlockExplosive.java
@@ -36,13 +36,14 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import voltaic.common.block.states.VoltaicBlockStates;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockExplosive extends Block {
 
     public final IBlast explosive;
 
     public BlockExplosive(IBlast explosive) {
-	super(Blocks.TNT.properties().instabreak().sound(SoundType.GRASS).noOcclusion()
+	super(VoltaicMaterials.explosive().instabreak().sound(SoundType.GRASS).noOcclusion()
 		.isRedstoneConductor((a, b, c) -> false));
 	this.explosive = explosive;
     }


### PR DESCRIPTION
When installed alongside Bad Packets, CraftedCore, and Create, any block that is set up in its registration using aFullCopy(Blocks.IRON_BLOCK) definition from any other mod is unable to be used as a texture for a Framed Block from the Framed Blocks mod if Voltaic or any of the other mods are installed. It also seems to affect glass and TNT.

I have fixed this by changing the super(Blocks.IRON_BLOCK) as well as the GLASS, TNT, and WHITE_WOOL entries to use the VoltaicMaterials.materialName() methods instead. This fixes the issue. It doesn't look like Modular Forcefields uses the super(Blocks.NAME) anywhere so I have not submitted a fix for it.