### PR TITLE
Fix dispenser duplication for explosives

### DIFF
--- a/src/main/java/ballistix/common/blockitem/BlockItemExplosive.java
+++ b/src/main/java/ballistix/common/blockitem/BlockItemExplosive.java
@@ -48,7 +48,7 @@ public class BlockItemExplosive extends BlockItemDescriptable {
 			SoundEvents.TNT_PRIMED, SoundSource.BLOCKS, 1.0F, 1.0F);
 
 	    }
-
+		item.shrink(1);
 	    return item;
 	}
 


### PR DESCRIPTION
The dispense() method in BlockItemExplosive's DispenseItemBehavior returned the unmodified ItemStack, causing the dispenser to write it back to inventory unchanged. This allowed unlimited explosives to be dispensed from a single stack. Calling item.shrink(1) inside the success path consumes one item per dispense, matching vanilla dispenser behavior. Landmines are unaffected (already excluded from dispenser registration).