### PR TITLE
tesselate compat

### DIFF
--- a/src/main/java/ballistix/api/missile/MissileManager.java
+++ b/src/main/java/ballistix/api/missile/MissileManager.java
@@ -1,340 +1,218 @@
 package ballistix.api.missile;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
 import ballistix.Ballistix;
 import ballistix.api.missile.virtual.VirtualMissile;
 import ballistix.api.missile.virtual.VirtualProjectile;
+import ballistix.compatibility.TessellateCompat;
 import ballistix.registers.BallistixAttachmentTypes;
+import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 @EventBusSubscriber(modid = Ballistix.ID, bus = EventBusSubscriber.Bus.GAME)
 public class MissileManager {
 
+    private static final Set<UUID> MISSILE_TASKS = ConcurrentHashMap.newKeySet();
+    private static final Set<UUID> BULLET_TASKS = ConcurrentHashMap.newKeySet();
+    private static final Set<UUID> RAILGUN_TASKS = ConcurrentHashMap.newKeySet();
+    private static final Set<UUID> SAM_TASKS = ConcurrentHashMap.newKeySet();
+
+    @SubscribeEvent
+    public static void initialize(ServerStartedEvent event) {
+	ServerLevel overworld = event.getServer().overworld();
+	overworld.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
+	overworld.getData(BallistixAttachmentTypes.ACTIVE_MISSILES);
+	overworld.getData(BallistixAttachmentTypes.ACTIVE_BULLETS);
+	overworld.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS);
+	overworld.getData(BallistixAttachmentTypes.ACTIVE_SAMS);
+    }
+
     @SubscribeEvent
     public static void tick(ServerTickEvent.Post event) {
-
 	ServerLevel overworld = getOverworld();
+	tickAll(event.getServer(), overworld.getData(BallistixAttachmentTypes.ACTIVE_MISSILES),
+		VirtualMissile::blockPosition, VirtualMissile::tick, VirtualMissile::hasExploded, MISSILE_TASKS);
+	tickAll(event.getServer(), overworld.getData(BallistixAttachmentTypes.ACTIVE_BULLETS),
+		VirtualProjectile.VirtualBullet::blockPosition, VirtualProjectile.VirtualBullet::tick,
+		VirtualProjectile.VirtualBullet::hasExploded, BULLET_TASKS);
+	tickAll(event.getServer(), overworld.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS),
+		VirtualProjectile.VirtualRailgunRound::blockPosition, VirtualProjectile.VirtualRailgunRound::tick,
+		VirtualProjectile.VirtualRailgunRound::hasExploded, RAILGUN_TASKS);
+	tickAll(event.getServer(), overworld.getData(BallistixAttachmentTypes.ACTIVE_SAMS),
+		VirtualProjectile.VirtualSAM::blockPosition, VirtualProjectile.VirtualSAM::tick,
+		VirtualProjectile.VirtualSAM::hasExploded, SAM_TASKS);
+    }
 
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> missiles = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES);
-
-	for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> entry : missiles.entrySet()) {
-
-	    ServerLevel level = event.getServer().getLevel(entry.getKey());
-
-	    // level isn't loaded
+    private static <T> void tickAll(MinecraftServer server,
+	    ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, T>> data, Function<T, BlockPos> position,
+	    BiConsumer<T, ServerLevel> ticker, Predicate<T> exploded, Set<UUID> inFlight) {
+	data.forEach((key, active) -> {
+	    ServerLevel level = server.getLevel(key);
 	    if (level == null) {
-		continue;
+		return;
 	    }
-
-	    Iterator<Map.Entry<UUID, VirtualMissile>> it = entry.getValue().entrySet().iterator();
-
-	    while (it.hasNext()) {
-
-		Map.Entry<UUID, VirtualMissile> active = it.next();
-
-		active.getValue().tick(level);
-
-		if (active.getValue().hasExploded()) {
-		    it.remove();
+	    if (!TessellateCompat.isLoaded()) {
+		active.forEach((id, value) -> tickOne(active, id, value, level, ticker, exploded));
+		return;
+	    }
+	    Map<Long, List<Map.Entry<UUID, T>>> batches = new HashMap<>();
+	    active.entrySet().forEach(entry -> {
+		BlockPos pos = position.apply(entry.getValue());
+		long chunk = net.minecraft.world.level.ChunkPos.asLong(pos.getX() >> 4, pos.getZ() >> 4);
+		batches.computeIfAbsent(chunk, ignored -> new ArrayList<>()).add(entry);
+	    });
+	    batches.values().forEach(batch -> {
+		List<Map.Entry<UUID, T>> claimed = batch.stream()
+			.filter(entry -> inFlight.add(entry.getKey()))
+			.toList();
+		if (claimed.isEmpty()) {
+		    return;
 		}
-
-	    }
-
-	}
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_MISSILES, missiles);
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> bullets = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_BULLETS);
-
-	for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> entry : bullets.entrySet()) {
-
-	    ServerLevel level = event.getServer().getLevel(entry.getKey());
-
-	    // level isn't loaded
-	    if (level == null) {
-		continue;
-	    }
-
-	    Iterator<Map.Entry<UUID, VirtualProjectile.VirtualBullet>> it = entry.getValue().entrySet().iterator();
-
-	    while (it.hasNext()) {
-
-		Map.Entry<UUID, VirtualProjectile.VirtualBullet> active = it.next();
-
-		active.getValue().tick(level);
-
-		if (active.getValue().hasExploded()) {
-		    it.remove();
+		try {
+		    BlockPos owner = position.apply(claimed.getFirst().getValue());
+		    TessellateCompat.runOnRegion(level, owner, () -> {
+			try {
+			    claimed.forEach(entry -> {
+				T value = entry.getValue();
+				if (active.get(entry.getKey()) == value) {
+				    tickOne(active, entry.getKey(), value, level, ticker, exploded);
+				}
+			    });
+			} finally {
+			    claimed.forEach(entry -> inFlight.remove(entry.getKey()));
+			}
+		    });
+		} catch (RuntimeException e) {
+		    claimed.forEach(entry -> inFlight.remove(entry.getKey()));
+		    throw e;
 		}
+	    });
+	});
+    }
 
-	    }
-
+    private static <T> void tickOne(ConcurrentHashMap<UUID, T> active, UUID id, T value, ServerLevel level,
+	    BiConsumer<T, ServerLevel> ticker, Predicate<T> exploded) {
+	ticker.accept(value, level);
+	if (exploded.test(value)) {
+	    active.remove(id, value);
 	}
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_BULLETS, bullets);
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> railgunrounds = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS);
-
-	for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> entry : railgunrounds
-		.entrySet()) {
-
-	    ServerLevel level = event.getServer().getLevel(entry.getKey());
-
-	    // level isn't loaded
-	    if (level == null) {
-		continue;
-	    }
-
-	    Iterator<Map.Entry<UUID, VirtualProjectile.VirtualRailgunRound>> it = entry.getValue().entrySet()
-		    .iterator();
-
-	    while (it.hasNext()) {
-
-		Map.Entry<UUID, VirtualProjectile.VirtualRailgunRound> active = it.next();
-
-		active.getValue().tick(level);
-
-		if (active.getValue().hasExploded()) {
-		    it.remove();
-		}
-
-	    }
-
-	}
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS, railgunrounds);
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> sams = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_SAMS);
-
-	for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> entry : sams.entrySet()) {
-
-	    ServerLevel level = event.getServer().getLevel(entry.getKey());
-
-	    // level isn't loaded
-	    if (level == null) {
-		continue;
-	    }
-
-	    Iterator<Map.Entry<UUID, VirtualProjectile.VirtualSAM>> it = entry.getValue().entrySet().iterator();
-
-	    while (it.hasNext()) {
-
-		Map.Entry<UUID, VirtualProjectile.VirtualSAM> active = it.next();
-
-		active.getValue().tick(level);
-
-		if (active.getValue().hasExploded()) {
-		    it.remove();
-		}
-
-	    }
-
-	}
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_SAMS, sams);
-
     }
 
     public static void addMissile(ResourceKey<Level> key, VirtualMissile missile) {
-
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES);
-
-	HashMap<UUID, VirtualMissile> virtual = data.getOrDefault(key, new HashMap<>());
-
-	virtual.put(missile.getId(), missile);
-
-	data.put(key, virtual);
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_MISSILES, data);
-
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_MISSILES)
+		.computeIfAbsent(key, ignored -> new ConcurrentHashMap<>()).put(missile.getId(), missile);
     }
 
     public static void removeMissile(ResourceKey<Level> level, UUID id) {
-
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES);
-
-	HashMap<UUID, VirtualMissile> virtual = data.getOrDefault(level, new HashMap<>());
-
-	virtual.remove(id);
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_MISSILES, data);
-
+	ConcurrentHashMap<UUID, VirtualMissile> missiles = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES).get(level);
+	if (missiles != null) {
+	    missiles.remove(id);
+	}
     }
 
     public static Collection<VirtualMissile> getMissilesForLevel(ResourceKey<Level> level) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES);
-
-	HashMap<UUID, VirtualMissile> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.values();
+	ConcurrentHashMap<UUID, VirtualMissile> missiles = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES).get(level);
+	return missiles == null ? List.of() : missiles.values();
     }
 
     @Nullable
     public static VirtualMissile getMissile(ResourceKey<Level> level, UUID id) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES);
-
-	HashMap<UUID, VirtualMissile> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.get(id);
+	ConcurrentHashMap<UUID, VirtualMissile> missiles = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_MISSILES).get(level);
+	return missiles == null ? null : missiles.get(id);
     }
 
     public static void wipeAllMissiles() {
-	getOverworld().removeData(BallistixAttachmentTypes.ACTIVE_MISSILES);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_MISSILES).clear();
     }
 
     public static void addBullet(ResourceKey<Level> key, VirtualProjectile.VirtualBullet bullet) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_BULLETS);
-
-	HashMap<UUID, VirtualProjectile.VirtualBullet> virtual = data.getOrDefault(key, new HashMap<>());
-
-	virtual.put(bullet.id, bullet);
-
-	data.put(key, virtual);
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_BULLETS, data);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_BULLETS)
+		.computeIfAbsent(key, ignored -> new ConcurrentHashMap<>()).put(bullet.id, bullet);
     }
 
     @Nullable
     public static VirtualProjectile.VirtualBullet getBullet(ResourceKey<Level> level, UUID id) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_BULLETS);
-
-	HashMap<UUID, VirtualProjectile.VirtualBullet> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.get(id);
+	ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet> bullets = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_BULLETS).get(level);
+	return bullets == null ? null : bullets.get(id);
     }
 
     public static Collection<VirtualProjectile.VirtualBullet> getBulletsForLevel(ResourceKey<Level> level) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_BULLETS);
-
-	HashMap<UUID, VirtualProjectile.VirtualBullet> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.values();
+	ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet> bullets = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_BULLETS).get(level);
+	return bullets == null ? List.of() : bullets.values();
     }
 
     public static void wipeAllBullets() {
-	getOverworld().removeData(BallistixAttachmentTypes.ACTIVE_BULLETS);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_BULLETS).clear();
     }
 
     public static void addRailgunRound(ResourceKey<Level> key, VirtualProjectile.VirtualRailgunRound railgun) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS);
-
-	HashMap<UUID, VirtualProjectile.VirtualRailgunRound> virtual = data.getOrDefault(key, new HashMap<>());
-
-	virtual.put(railgun.id, railgun);
-
-	data.put(key, virtual);
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS, data);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS)
+		.computeIfAbsent(key, ignored -> new ConcurrentHashMap<>()).put(railgun.id, railgun);
     }
 
     @Nullable
     public static VirtualProjectile.VirtualRailgunRound getRailgunRound(ResourceKey<Level> level, UUID id) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS);
-
-	HashMap<UUID, VirtualProjectile.VirtualRailgunRound> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.get(id);
+	ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound> rounds = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS).get(level);
+	return rounds == null ? null : rounds.get(id);
     }
 
     public static Collection<VirtualProjectile.VirtualRailgunRound> getRailgunRoundsForLevel(ResourceKey<Level> level) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS);
-
-	HashMap<UUID, VirtualProjectile.VirtualRailgunRound> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.values();
+	ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound> rounds = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS).get(level);
+	return rounds == null ? List.of() : rounds.values();
     }
 
     public static void wipeAllRailgunRounds() {
-	getOverworld().removeData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_RAILGUNROUNDS).clear();
     }
 
     public static void addSAM(ResourceKey<Level> key, VirtualProjectile.VirtualSAM bullet) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_SAMS);
-
-	HashMap<UUID, VirtualProjectile.VirtualSAM> virtual = data.getOrDefault(key, new HashMap<>());
-
-	virtual.put(bullet.id, bullet);
-
-	data.put(key, virtual);
-
-	overworld.setData(BallistixAttachmentTypes.ACTIVE_SAMS, data);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_SAMS)
+		.computeIfAbsent(key, ignored -> new ConcurrentHashMap<>()).put(bullet.id, bullet);
     }
 
     @Nullable
     public static VirtualProjectile.VirtualSAM getSAM(ResourceKey<Level> level, UUID id) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_SAMS);
-
-	HashMap<UUID, VirtualProjectile.VirtualSAM> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.get(id);
+	ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM> sams = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_SAMS).get(level);
+	return sams == null ? null : sams.get(id);
     }
 
     public static Collection<VirtualProjectile.VirtualSAM> getSAMsForLevel(ResourceKey<Level> level) {
-	ServerLevel overworld = getOverworld();
-
-	HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> data = overworld
-		.getData(BallistixAttachmentTypes.ACTIVE_SAMS);
-
-	HashMap<UUID, VirtualProjectile.VirtualSAM> virtual = data.getOrDefault(level, new HashMap<>());
-
-	return virtual.values();
+	ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM> sams = getOverworld()
+		.getData(BallistixAttachmentTypes.ACTIVE_SAMS).get(level);
+	return sams == null ? List.of() : sams.values();
     }
 
     public static void wipeAllSAMs() {
-	getOverworld().removeData(BallistixAttachmentTypes.ACTIVE_SAMS);
+	getOverworld().getData(BallistixAttachmentTypes.ACTIVE_SAMS).clear();
     }
 
     private static ServerLevel getOverworld() {

--- a/src/main/java/ballistix/api/missile/virtual/VirtualMissile.java
+++ b/src/main/java/ballistix/api/missile/virtual/VirtualMissile.java
@@ -17,6 +17,7 @@ import ballistix.common.block.subtype.SubtypeMissile;
 import ballistix.common.entity.EntityBlast;
 import ballistix.common.entity.EntityMissile;
 import ballistix.common.settings.BallistixConfig;
+import ballistix.compatibility.TessellateCompat;
 import ballistix.registers.BallistixSounds;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.UUIDUtil;
@@ -66,20 +67,21 @@ public class VirtualMissile {
     //
     ).apply(instance, VirtualMissile::new));
 
-    public Vec3 position = Vec3.ZERO;
-    public Vec3 deltaMovement = Vec3.ZERO;
-    public float speed = 0.0F;
-    public float health = BallistixConfig.INSTANCE.MISSILE_HEALTH.get();
+	public volatile Vec3 position = Vec3.ZERO;
+	public volatile Vec3 deltaMovement = Vec3.ZERO;
+	public volatile float speed = 0.0F;
+	public volatile float health = BallistixConfig.INSTANCE.MISSILE_HEALTH.get();
     private final UUID id;
-    private boolean hasExploded = false;
+	private volatile boolean hasExploded = false;
     public final MissileEntityData entityData;
     public final MissileTargetData targetData;
     public final MissilePayloadData payloadData;
 
-    private int tickCount = 0;
+    private volatile int tickCount = 0;
+    private volatile boolean spawnPending;
 
     @Nullable
-    public EntityBlast blastEntity;
+	public volatile EntityBlast blastEntity;
 
     private VirtualMissile(Vec3 pos, Vec3 deltaMovement, float speed, float health, boolean hasExploded, UUID id,
 	    int tickCount, MissileTargetData targetData, MissileEntityData entityData, MissilePayloadData payloadData) {
@@ -432,7 +434,7 @@ public class VirtualMissile {
 	    speed += 0.02F;
 	}
 
-	if (!entityData.isSpawned && level.hasChunkAt(blockPosition())
+	if (!spawnPending && !entityData.isSpawned && level.hasChunkAt(blockPosition())
 		&& level.isPositionEntityTicking(blockPosition())) {
 
 	    EntityMissile missile = new EntityMissile(level);
@@ -446,8 +448,20 @@ public class VirtualMissile {
 	    missile.startX = targetData.startX;
 	    missile.startZ = targetData.startZ;
 
-	    if (level.addFreshEntity(missile)) {
-		setSpawned(true, missile.getId());
+	    spawnPending = true;
+	    try {
+		TessellateCompat.runOnMain(() -> {
+		    try {
+			if (!hasExploded && level.addFreshEntity(missile)) {
+			    setSpawned(true, missile.getId());
+			}
+		    } finally {
+			spawnPending = false;
+		    }
+		});
+	    } catch (RuntimeException e) {
+		spawnPending = false;
+		throw e;
 	    }
 
 	}
@@ -512,8 +526,8 @@ public class VirtualMissile {
     }
 
     public void setSpawned(boolean spawned, int id) {
-	entityData.isSpawned = spawned;
 	entityData.entityId = id;
+	entityData.isSpawned = spawned;
     }
 
     public AABB getBoundingBox() {
@@ -558,8 +572,8 @@ public class VirtualMissile {
 	//
 	).apply(instance, MissileEntityData::new));
 
-	public boolean isSpawned = false;
-	public int entityId = -1;
+	public volatile boolean isSpawned = false;
+	public volatile int entityId = -1;
 
 	public MissileEntityData(boolean isSpawned, int entityId) {
 	    this.entityId = entityId;
@@ -587,7 +601,7 @@ public class VirtualMissile {
 	public final float startX;
 	public final float startZ;
 	public final BlockPos target;
-	public boolean pastHalfwayPoint = false;
+	public volatile boolean pastHalfwayPoint = false;
 	public final boolean usingAirburst;
 
 	public MissileTargetData(float startX, float startZ, BlockPos target, boolean pastHalfway,
@@ -620,7 +634,7 @@ public class VirtualMissile {
 	public final ResourceLocation blastId;
 	public final int frequency;
 	private final int flightPath;
-	public boolean hasIgnighted;
+	public volatile boolean hasIgnighted;
 
 	public MissilePayloadData(int missileType, ResourceLocation blastId, int frequency, int flightPath,
 		boolean hasIgnighted) {

--- a/src/main/java/ballistix/api/missile/virtual/VirtualProjectile.java
+++ b/src/main/java/ballistix/api/missile/virtual/VirtualProjectile.java
@@ -18,6 +18,7 @@ import ballistix.common.entity.EntitySAM;
 import ballistix.common.settings.BallistixConfig;
 import ballistix.common.tile.radar.TileFireControlRadar;
 import ballistix.common.tile.turret.GenericTileTurret;
+import ballistix.compatibility.TessellateCompat;
 import ballistix.registers.BallistixDamageTypes;
 import ballistix.registers.BallistixSounds;
 import net.minecraft.core.BlockPos;
@@ -40,17 +41,18 @@ import voltaic.prefab.utilities.BlockEntityUtils;
 
 public abstract class VirtualProjectile {
 
-    public float speed;
-    public Vec3 position;
-    public Vec3 deltaMovement;
+	public volatile float speed;
+	public volatile Vec3 position;
+	public volatile Vec3 deltaMovement;
     public final float range;
     public final boolean canHitPlayers;
     public final UUID id;
-    protected boolean hasExploded = false;
-    protected boolean isSpawned = false;
-    public float distanceTraveled = 0.0F;
+	protected volatile boolean hasExploded = false;
+	protected volatile boolean isSpawned = false;
+	public volatile float distanceTraveled = 0.0F;
     protected int tickCount = 0;
-    protected int entityId = -1;
+	protected volatile int entityId = -1;
+    private volatile boolean spawnPending;
 
     protected VirtualProjectile(float speed, Vec3 position, Vec3 deltaMovement, float range, boolean canHitPlayers,
 	    float distanceTraveled, UUID id, boolean hasExploded, boolean isSpawned, int entityId) {
@@ -147,10 +149,23 @@ public abstract class VirtualProjectile {
 
 	distanceTraveled += speed;
 
-	if (!isSpawned && level.hasChunkAt(blockPosition()) && level.isPositionEntityTicking(blockPosition())) {
+	if (!spawnPending && !isSpawned && level.hasChunkAt(blockPosition())
+		&& level.isPositionEntityTicking(blockPosition())) {
 	    Entity entity = makeNewEntity(level);
-	    if (level.addFreshEntity(entity)) {
-		setSpawned(true, entity.getId());
+	    spawnPending = true;
+	    try {
+		TessellateCompat.runOnMain(() -> {
+		    try {
+			if (!hasExploded && level.addFreshEntity(entity)) {
+			    setSpawned(true, entity.getId());
+			}
+		    } finally {
+			spawnPending = false;
+		    }
+		});
+	    } catch (RuntimeException e) {
+		spawnPending = false;
+		throw e;
 	    }
 	}
 
@@ -193,8 +208,8 @@ public abstract class VirtualProjectile {
     }
 
     public void setSpawned(boolean spawned, int id) {
-	isSpawned = spawned;
 	entityId = id;
+	isSpawned = spawned;
     }
 
     public boolean hasExploded() {

--- a/src/main/java/ballistix/api/silo/SiloRegistry.java
+++ b/src/main/java/ballistix/api/silo/SiloRegistry.java
@@ -1,7 +1,8 @@
 package ballistix.api.silo;
 
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import ballistix.registers.BallistixAttachmentTypes;
 import net.minecraft.core.BlockPos;
@@ -13,15 +14,9 @@ public class SiloRegistry {
     public static void registerSilo(int frequency, ILauncherControlPanel silo) {
 	ServerLevel overworld = getOverworld();
 
-	HashMap<Integer, HashSet<BlockPos>> siloRegistry = overworld.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
-
-	HashSet<BlockPos> registered = siloRegistry.getOrDefault(frequency, new HashSet<>());
-
-	registered.add(silo.getPos());
-
-	siloRegistry.put(frequency, registered);
-
-	overworld.setData(BallistixAttachmentTypes.SILO_FREQUENCIES, siloRegistry);
+	ConcurrentHashMap<Integer, Set<BlockPos>> siloRegistry = overworld
+		.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
+	siloRegistry.computeIfAbsent(frequency, ignored -> ConcurrentHashMap.newKeySet()).add(silo.getPos());
 
     }
 
@@ -29,26 +24,29 @@ public class SiloRegistry {
 
 	ServerLevel overworld = getOverworld();
 
-	HashMap<Integer, HashSet<BlockPos>> siloRegistry = overworld.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
+	ConcurrentHashMap<Integer, Set<BlockPos>> siloRegistry = overworld
+		.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
+	Set<BlockPos> registered = siloRegistry.get(frequency);
+	if (registered != null) {
+	    registered.remove(silo.getPos());
+	}
+    }
 
-	HashSet<BlockPos> registered = siloRegistry.getOrDefault(frequency, new HashSet<>());
-
-	registered.remove(silo.getPos());
-
-	siloRegistry.put(frequency, registered);
-
-	overworld.setData(BallistixAttachmentTypes.SILO_FREQUENCIES, siloRegistry);
+    public static Set<BlockPos> getSiloPositions(int frequency) {
+	Set<BlockPos> positions = getOverworld().getData(BallistixAttachmentTypes.SILO_FREQUENCIES).get(frequency);
+	return positions == null ? Set.of() : Set.copyOf(positions);
     }
 
     public static HashSet<ILauncherControlPanel> getSilos(int freq) {
 
 	ServerLevel overworld = getOverworld();
 
-	HashMap<Integer, HashSet<BlockPos>> siloRegistry = overworld.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
+	ConcurrentHashMap<Integer, Set<BlockPos>> siloRegistry = overworld
+		.getData(BallistixAttachmentTypes.SILO_FREQUENCIES);
 
 	HashSet<ILauncherControlPanel> silos = new HashSet<>();
 
-	for (BlockPos pos : siloRegistry.getOrDefault(freq, new HashSet<>())) {
+	for (BlockPos pos : siloRegistry.getOrDefault(freq, Set.of())) {
 
 	    if (overworld.getBlockEntity(pos) instanceof ILauncherControlPanel silo) {
 		silos.add(silo);

--- a/src/main/java/ballistix/common/blast/util/Blast.java
+++ b/src/main/java/ballistix/common/blast/util/Blast.java
@@ -1,15 +1,11 @@
 package ballistix.common.blast.util;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.Maps;
 import com.mojang.authlib.GameProfile;
 
 import ballistix.Ballistix;
@@ -21,6 +17,7 @@ import ballistix.api.event.BlastEvent.ConstructBlastEvent;
 import ballistix.api.event.BlastEvent.PostBlastEvent;
 import ballistix.api.event.BlastEvent.PreBlastEvent;
 import ballistix.common.entity.EntityBlast;
+import ballistix.compatibility.TessellateCompat;
 import ballistix.compatibility.griefdefender.GriefDefenderHandler;
 import modularforcefields.common.settings.MFFSConfig;
 import modularforcefields.common.tile.TileFortronFieldProjector;
@@ -36,7 +33,6 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.PrimedTnt;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
@@ -223,7 +219,6 @@ public abstract class Blast {
     }
 
     protected void attackEntities(float size, boolean useRaytrace, Explosion explosion) {
-	Map<Player, Vec3> playerKnockbackMap = Maps.newHashMap();
 	float doubleSize = size * 2.0F;
 	int x0 = Mth.floor(position.getX() - (double) doubleSize - 1.0D);
 	int x1 = Mth.floor(position.getX() + (double) doubleSize + 1.0D);
@@ -237,64 +232,65 @@ public abstract class Blast {
 	Vec3 posVector = new Vec3(position.getX(), position.getY(), position.getZ());
 
 	for (Entity entity : entities) {
-
-	    boolean ignoreEntity = entity.ignoreExplosion(explosion) || !canHarmEntity(entity);
-	    if (ignoreEntity) {
-		continue;
-	    }
-
-	    double normalizedDiameter = Mth.sqrt((float) entity.distanceToSqr(posVector)) / doubleSize;
-	    if (normalizedDiameter > 1.0D) {
-		continue;
-	    }
-	    double deltaX = entity.getX() - position.getX();
-	    double deltaY = (entity instanceof PrimedTnt ? entity.getY() : entity.getEyeY()) - position.getY();
-	    double deltaZ = entity.getZ() - position.getZ();
-	    double deltaDistance = Mth.sqrt((float) (deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ));
-
-	    if (deltaDistance == 0.0D) {
-		continue;
-	    }
-
-	    deltaX = deltaX / deltaDistance;
-	    deltaY = deltaY / deltaDistance;
-	    deltaZ = deltaZ / deltaDistance;
-
-	    double seenAmount = useRaytrace ? Explosion.getSeenPercent(posVector, entity) : 1;
-
-	    double damageAmount = (1.0D - normalizedDiameter) * seenAmount;
-
-	    entity.hurt(Explosion.getDefaultDamageSource(world, owner),
-		    (int) ((damageAmount * damageAmount + damageAmount) / 2.0D * 7.0D * doubleSize + 1.0D));
-
-	    double actualDamage = damageAmount;
-
-	    if (entity instanceof LivingEntity le) {
-		double damage = damageAmount;
-		int i = EnchantmentHelper
-			.getEnchantmentLevel(world.registryAccess().holderOrThrow(Enchantments.BLAST_PROTECTION), le);
-		if (i > 0) {
-		    damage *= Mth.clamp(1.0D - i * 0.15D, 0.0D, 1.0D);
-		}
-
-		actualDamage = damage;
-	    }
-
-	    entity.push(deltaX * actualDamage, deltaY * actualDamage, deltaZ * actualDamage);
-	    if (entity instanceof Player playerentity) {
-		if (!playerentity.isSpectator()
-			&& (!playerentity.isCreative() || !playerentity.getAbilities().flying)) {
-		    playerKnockbackMap.put(playerentity,
-			    new Vec3(deltaX * damageAmount, deltaY * damageAmount, deltaZ * damageAmount));
-		}
+	    if (world instanceof ServerLevel level) {
+		TessellateCompat.runOnRegion(level, entity.blockPosition(),
+			() -> attackEntity(entity, size, doubleSize, useRaytrace, explosion, posVector));
+	    } else {
+		attackEntity(entity, size, doubleSize, useRaytrace, explosion, posVector);
 	    }
 	}
-	for (Entry<Player, Vec3> entry : playerKnockbackMap.entrySet()) {
-	    if (entry.getKey() instanceof ServerPlayer serverplayerentity) {
-		serverplayerentity.connection.send(new ClientboundExplodePacket(position.getX(), position.getY(),
-			position.getZ(), size, new ArrayList<>(), entry.getValue(), BlockInteraction.DESTROY,
-			ParticleTypes.EXPLOSION, ParticleTypes.EXPLOSION_EMITTER, SoundEvents.GENERIC_EXPLODE));
+    }
+    private void attackEntity(Entity entity, float size, float doubleSize, boolean useRaytrace, Explosion explosion,
+	    Vec3 posVector) {
+	boolean ignoreEntity = entity.ignoreExplosion(explosion) || !canHarmEntity(entity);
+	if (ignoreEntity) {
+	    return;
+	}
+
+	double normalizedDiameter = Mth.sqrt((float) entity.distanceToSqr(posVector)) / doubleSize;
+	if (normalizedDiameter > 1.0D) {
+	    return;
+	}
+	double deltaX = entity.getX() - position.getX();
+	double deltaY = (entity instanceof PrimedTnt ? entity.getY() : entity.getEyeY()) - position.getY();
+	double deltaZ = entity.getZ() - position.getZ();
+	double deltaDistance = Mth.sqrt((float) (deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ));
+
+	if (deltaDistance == 0.0D) {
+	    return;
+	}
+
+	deltaX = deltaX / deltaDistance;
+	deltaY = deltaY / deltaDistance;
+	deltaZ = deltaZ / deltaDistance;
+
+	double seenAmount = useRaytrace ? Explosion.getSeenPercent(posVector, entity) : 1;
+
+	double damageAmount = (1.0D - normalizedDiameter) * seenAmount;
+
+	entity.hurt(Explosion.getDefaultDamageSource(world, owner),
+		(int) ((damageAmount * damageAmount + damageAmount) / 2.0D * 7.0D * doubleSize + 1.0D));
+
+	double actualDamage = damageAmount;
+
+	if (entity instanceof LivingEntity le) {
+	    double damage = damageAmount;
+	    int i = EnchantmentHelper
+		    .getEnchantmentLevel(world.registryAccess().holderOrThrow(Enchantments.BLAST_PROTECTION), le);
+	    if (i > 0) {
+		damage *= Mth.clamp(1.0D - i * 0.15D, 0.0D, 1.0D);
 	    }
+
+	    actualDamage = damage;
+	}
+
+	entity.push(deltaX * actualDamage, deltaY * actualDamage, deltaZ * actualDamage);
+	if (entity instanceof ServerPlayer player && !player.isSpectator()
+		&& (!player.isCreative() || !player.getAbilities().flying)) {
+	    player.connection.send(new ClientboundExplodePacket(position.getX(), position.getY(), position.getZ(), size,
+		    List.of(), new Vec3(deltaX * damageAmount, deltaY * damageAmount, deltaZ * damageAmount),
+		    BlockInteraction.DESTROY, ParticleTypes.EXPLOSION, ParticleTypes.EXPLOSION_EMITTER,
+		    SoundEvents.GENERIC_EXPLODE));
 	}
     }
 

--- a/src/main/java/ballistix/common/blast/util/thread/ThreadBlast.java
+++ b/src/main/java/ballistix/common/blast/util/thread/ThreadBlast.java
@@ -17,7 +17,7 @@ public abstract class ThreadBlast extends Thread {
     public float explosionEnergy;
     public Entity explosionSource;
 
-    public boolean isComplete = false;
+	public volatile boolean isComplete = false;
 
     protected ThreadBlast(Level world, BlockPos pos, int radius, float energy, Entity source) {
 	level = world;

--- a/src/main/java/ballistix/common/blast/util/thread/raycast/ThreadDynamicRaySideBlast.java
+++ b/src/main/java/ballistix/common/blast/util/thread/raycast/ThreadDynamicRaySideBlast.java
@@ -99,6 +99,8 @@ public class ThreadDynamicRaySideBlast extends Thread {
 		}
 	    }
 	}
-	mainBlast.underBlasts.remove(this);
+	synchronized (mainBlast.underBlasts) {
+	    mainBlast.underBlasts.remove(this);
+	}
     }
 }

--- a/src/main/java/ballistix/common/blast/util/thread/raycast/ThreadDynamicRaycastBlast.java
+++ b/src/main/java/ballistix/common/blast/util/thread/raycast/ThreadDynamicRaycastBlast.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import ballistix.common.blast.util.thread.ThreadBlast;
 import ballistix.common.settings.BallistixConfig;
+import ballistix.compatibility.TessellateCompat;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
@@ -62,19 +63,30 @@ public class ThreadDynamicRaycastBlast extends ThreadBlast {
     }
 
     @Override
+    public synchronized void start() {
+	if (TessellateCompat.isLoaded()) {
+	    run();
+	} else {
+	    super.start();
+	}
+    }
+
+    @Override
     public void run() {
 	results.add(new HashDistanceBlockPos(position.getX(), position.getY(), position.getZ(), 0));
 	for (Direction dir : Direction.values()) {
 	    ThreadDynamicRaySideBlast sideBlast = new ThreadDynamicRaySideBlast(this, dir);
-	    underBlasts.add(sideBlast);
-	    if (BallistixConfig.INSTANCE.SHOULD_MULTITHREAD_RAYTRACING.isTrue()) {
+	    synchronized (underBlasts) {
+		underBlasts.add(sideBlast);
+	    }
+	    if (shouldMultithread()) {
 		sideBlast.start();
 	    } else {
 		sideBlast.run();
 	    }
 	}
-	if (BallistixConfig.INSTANCE.SHOULD_MULTITHREAD_RAYTRACING.isTrue()) {
-	    while (!underBlasts.isEmpty()) {
+	if (shouldMultithread()) {
+	    while (hasUnderBlasts()) {
 		HashSet<BlockPos> current = new HashSet<>();
 		synchronized (intermediateResults) {
 		    current.addAll(intermediateResults);
@@ -94,6 +106,16 @@ public class ThreadDynamicRaycastBlast extends ThreadBlast {
 	    finishedBlocks.addAll(intermediateResults);
 	}
 	super.run();
+    }
+
+    private static boolean shouldMultithread() {
+	return BallistixConfig.INSTANCE.SHOULD_MULTITHREAD_RAYTRACING.isTrue() && !TessellateCompat.isLoaded();
+    }
+
+    private boolean hasUnderBlasts() {
+	synchronized (underBlasts) {
+	    return !underBlasts.isEmpty();
+	}
     }
 
     public static record IResistanceCallbackImp(Explosion explosion) implements IResistanceCallback {

--- a/src/main/java/ballistix/common/item/ItemLaserDesignator.java
+++ b/src/main/java/ballistix/common/item/ItemLaserDesignator.java
@@ -1,10 +1,12 @@
 package ballistix.common.item;
 
 import java.util.List;
+import java.util.Set;
 
 import ballistix.api.silo.ILauncherControlPanel;
 import ballistix.api.silo.ILauncherPlatform;
 import ballistix.api.silo.SiloRegistry;
+import ballistix.compatibility.TessellateCompat;
 import ballistix.common.settings.BallistixConfig;
 import ballistix.common.tile.silo.TileLauncherControlPanelT1;
 import ballistix.prefab.utils.BallistixTextUtils;
@@ -13,6 +15,7 @@ import ballistix.registers.BallistixDataComponentTypes;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -91,34 +94,40 @@ public class ItemLaserDesignator extends ItemElectric {
 
 	int frequency = designator.get(BallistixDataComponentTypes.BOUND_FREQUENCY);
 
-	int range;
-
 	BlockPos target = trace.toBlockPos();
+	Set<BlockPos> siloPositions = SiloRegistry.getSiloPositions(frequency);
 
-	double distance;
+	if (siloPositions.isEmpty()) {
+	    return super.use(worldIn, playerIn, handIn);
+	}
 
-	for (ILauncherControlPanel silo : SiloRegistry.getSilos(frequency)) {
+	extractPower(designator, USAGE, false);
+	ServerLevel level = (ServerLevel) worldIn;
+	for (BlockPos siloPos : siloPositions) {
+	    TessellateCompat.runOnRegion(level, siloPos, () -> {
+		if (!(level.getBlockEntity(siloPos) instanceof ILauncherControlPanel silo)) {
+		    return;
+		}
 
-	    ILauncherPlatform platform = silo.getPlatform();
+		ILauncherPlatform platform = silo.getPlatform();
 
-	    if (platform == null) {
-		continue;
-	    }
+		if (platform == null) {
+		    return;
+		}
 
-	    range = platform.getRange();
-	    distance = TileLauncherControlPanelT1.calculateDistance(silo.getPos(), target);
+		int range = platform.getRange();
+		double distance = TileLauncherControlPanelT1.calculateDistance(silo.getPos(), target);
 
-	    if (range == 0 || range > 0 && range < distance
-		    || distance > BallistixConfig.INSTANCE.LASER_DESIGNATOR_RANGE.get()) {
-		continue;
-	    }
+		if (range == 0 || range > 0 && range < distance
+			|| distance > BallistixConfig.INSTANCE.LASER_DESIGNATOR_RANGE.get()) {
+		    return;
+		}
 
-	    silo.setTargetFromDesignator(trace.toBlockPos());
+		silo.setTargetFromDesignator(target);
 
-	    silo.launch();
+		silo.launch();
 
-	    extractPower(designator, USAGE, false);
-
+	    });
 	}
 
 	playerIn.displayClientMessage(BallistixTextUtils.chatMessage("laserdesignator.launch", frequency), false);

--- a/src/main/java/ballistix/common/packet/type/client/ClientBarrierMethods.java
+++ b/src/main/java/ballistix/common/packet/type/client/ClientBarrierMethods.java
@@ -1,6 +1,7 @@
 package ballistix.common.packet.type.client;
 
 import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import ballistix.api.radar.IDetected;
@@ -16,8 +17,7 @@ import net.minecraft.world.entity.player.Player;
 public class ClientBarrierMethods {
     public static void handleSetSearchRadarTrackedClient(HashSet<IDetected.Detected> detected, BlockPos tilePos) {
 	if (Minecraft.getInstance().level.getBlockEntity(tilePos) instanceof TileSearchRadar radar) {
-	    radar.detections.clear();
-	    radar.detections.addAll(detected);
+	    radar.detections = Set.copyOf(detected);
 	}
     }
 

--- a/src/main/java/ballistix/common/tile/TileESMTower.java
+++ b/src/main/java/ballistix/common/tile/TileESMTower.java
@@ -1,9 +1,7 @@
 package ballistix.common.tile;
 
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import ballistix.Ballistix;
@@ -45,9 +43,9 @@ import voltaic.registers.VoltaicCapabilities;
 
 public class TileESMTower extends GenericTile implements IMultiblockParentTile {
 
-    public static final ConcurrentHashMap<ResourceKey<Level>, HashSet<TileSearchRadar>> SEARCH_RADARS = new ConcurrentHashMap<>();
-    public static final ConcurrentHashMap<ResourceKey<Level>, HashSet<TileFireControlRadar>> FIRE_CONTROL_RADARS = new ConcurrentHashMap<>();
-    public static final ConcurrentHashMap<ResourceKey<Level>, HashSet<TileESMTower>> ESM_TOWERS = new ConcurrentHashMap<>();
+	public static final ConcurrentHashMap<ResourceKey<Level>, Set<TileSearchRadar>> SEARCH_RADARS = new ConcurrentHashMap<>();
+	public static final ConcurrentHashMap<ResourceKey<Level>, Set<TileFireControlRadar>> FIRE_CONTROL_RADARS = new ConcurrentHashMap<>();
+	public static final ConcurrentHashMap<ResourceKey<Level>, Set<TileESMTower>> ESM_TOWERS = new ConcurrentHashMap<>();
 
     public final SingleProperty<Boolean> active = property(
 	    new SingleProperty<>(PropertyTypes.BOOLEAN, "active", false));
@@ -91,14 +89,14 @@ public class TileESMTower extends GenericTile implements IMultiblockParentTile {
 	searchRadarDetected.setValue(false);
 	fireControlRadars.wipeList();
 
-	for (TileSearchRadar radar : SEARCH_RADARS.getOrDefault(getLevel().dimension(), new HashSet<>())) {
+	for (TileSearchRadar radar : SEARCH_RADARS.getOrDefault(getLevel().dimension(), Set.of())) {
 	    if (searchArea.intersects(new AABB(radar.getBlockPos()))) {
 		searchRadarDetected.setValue(true);
 		break;
 	    }
 	}
 
-	for (TileFireControlRadar radar : FIRE_CONTROL_RADARS.getOrDefault(getLevel().dimension(), new HashSet<>())) {
+	for (TileFireControlRadar radar : FIRE_CONTROL_RADARS.getOrDefault(getLevel().dimension(), Set.of())) {
 	    if (searchArea.intersects(new AABB(radar.getBlockPos()))) {
 		fireControlRadars.addValue(radar.getBlockPos());
 	    }
@@ -127,34 +125,38 @@ public class TileESMTower extends GenericTile implements IMultiblockParentTile {
     }
 
     public static void removeSearchRadar(TileSearchRadar radar) {
-	SEARCH_RADARS.getOrDefault(radar.getLevel().dimension(), new HashSet<>()).remove(radar);
+	Set<TileSearchRadar> radars = SEARCH_RADARS.get(radar.getLevel().dimension());
+	if (radars != null) {
+	    radars.remove(radar);
+	}
     }
 
     public static void removeFireControlRadar(TileFireControlRadar radar) {
-	FIRE_CONTROL_RADARS.getOrDefault(radar.getLevel().dimension(), new HashSet<>()).remove(radar);
+	Set<TileFireControlRadar> radars = FIRE_CONTROL_RADARS.get(radar.getLevel().dimension());
+	if (radars != null) {
+	    radars.remove(radar);
+	}
     }
 
     public static void removeESMTower(TileESMTower esm) {
-	ESM_TOWERS.getOrDefault(esm.getLevel().dimension(), new HashSet<>()).remove(esm);
+	Set<TileESMTower> towers = ESM_TOWERS.get(esm.getLevel().dimension());
+	if (towers != null) {
+	    towers.remove(esm);
+	}
     }
 
     public static void addSearchRadar(TileSearchRadar radar) {
-	HashSet<TileSearchRadar> radars = SEARCH_RADARS.getOrDefault(radar.getLevel().dimension(), new HashSet<>());
-	radars.add(radar);
-	SEARCH_RADARS.put(radar.getLevel().dimension(), radars);
+	SEARCH_RADARS.computeIfAbsent(radar.getLevel().dimension(), ignored -> ConcurrentHashMap.newKeySet())
+		.add(radar);
     }
 
     public static void addFireControlRadar(TileFireControlRadar radar) {
-	HashSet<TileFireControlRadar> radars = FIRE_CONTROL_RADARS.getOrDefault(radar.getLevel().dimension(),
-		new HashSet<>());
-	radars.add(radar);
-	FIRE_CONTROL_RADARS.put(radar.getLevel().dimension(), radars);
+	FIRE_CONTROL_RADARS.computeIfAbsent(radar.getLevel().dimension(), ignored -> ConcurrentHashMap.newKeySet())
+		.add(radar);
     }
 
     public static void addESMTower(TileESMTower esm) {
-	HashSet<TileESMTower> esmTowers = ESM_TOWERS.getOrDefault(esm.getLevel().dimension(), new HashSet<>());
-	esmTowers.add(esm);
-	ESM_TOWERS.put(esm.getLevel().dimension(), esmTowers);
+	ESM_TOWERS.computeIfAbsent(esm.getLevel().dimension(), ignored -> ConcurrentHashMap.newKeySet()).add(esm);
     }
 
     @EventBusSubscriber(modid = Ballistix.ID, bus = EventBusSubscriber.Bus.GAME)
@@ -162,61 +164,9 @@ public class TileESMTower extends GenericTile implements IMultiblockParentTile {
 
 	@SubscribeEvent
 	private static void clearMaps(ServerTickEvent.Post event) {
-
-	    Iterator<Map.Entry<ResourceKey<Level>, HashSet<TileSearchRadar>>> searchIterator = SEARCH_RADARS.entrySet()
-		    .iterator();
-
-	    while (searchIterator.hasNext()) {
-		Map.Entry<ResourceKey<Level>, HashSet<TileSearchRadar>> entry = searchIterator.next();
-
-		Iterator<TileSearchRadar> it = entry.getValue().iterator();
-
-		while (it.hasNext()) {
-		    TileSearchRadar radar = it.next();
-
-		    if (radar == null || radar.isRemoved()) {
-			it.remove();
-		    }
-		}
-
-	    }
-
-	    Iterator<Map.Entry<ResourceKey<Level>, HashSet<TileFireControlRadar>>> fireIterator = FIRE_CONTROL_RADARS
-		    .entrySet().iterator();
-
-	    while (fireIterator.hasNext()) {
-		Map.Entry<ResourceKey<Level>, HashSet<TileFireControlRadar>> entry = fireIterator.next();
-
-		Iterator<TileFireControlRadar> it = entry.getValue().iterator();
-
-		while (it.hasNext()) {
-		    TileFireControlRadar radar = it.next();
-
-		    if (radar == null || radar.isRemoved()) {
-			it.remove();
-		    }
-		}
-
-	    }
-
-	    Iterator<Map.Entry<ResourceKey<Level>, HashSet<TileESMTower>>> esmIterator = ESM_TOWERS.entrySet()
-		    .iterator();
-
-	    while (esmIterator.hasNext()) {
-		Map.Entry<ResourceKey<Level>, HashSet<TileESMTower>> entry = esmIterator.next();
-
-		Iterator<TileESMTower> it = entry.getValue().iterator();
-
-		while (it.hasNext()) {
-		    TileESMTower radar = it.next();
-
-		    if (radar == null || radar.isRemoved()) {
-			it.remove();
-		    }
-		}
-
-	    }
-
+	    SEARCH_RADARS.values().forEach(radars -> radars.removeIf(radar -> radar == null || radar.isRemoved()));
+	    FIRE_CONTROL_RADARS.values().forEach(radars -> radars.removeIf(radar -> radar == null || radar.isRemoved()));
+	    ESM_TOWERS.values().forEach(towers -> towers.removeIf(tower -> tower == null || tower.isRemoved()));
 	}
     }
 

--- a/src/main/java/ballistix/common/tile/radar/TileFireControlRadar.java
+++ b/src/main/java/ballistix/common/tile/radar/TileFireControlRadar.java
@@ -1,7 +1,6 @@
 package ballistix.common.tile.radar;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -73,13 +72,13 @@ public class TileFireControlRadar extends GenericTile {
     private final AABB searchArea = new AABB(getBlockPos())
 	    .inflate(BallistixConfig.INSTANCE.FIRE_CONTROL_RADAR_RANGE.get());
     @Nullable
-    public VirtualMissile tracking;
+	public volatile VirtualMissile tracking;
 
     private final ArrayList<VirtualMissile> trackedMissiles = new ArrayList<>();
     private final Map<BlockPos, UUID> assignments = new HashMap<>();
 
-    public List<VirtualMissile> getTrackedMissiles() {
-	return Collections.unmodifiableList(trackedMissiles);
+	public synchronized List<VirtualMissile> getTrackedMissiles() {
+	return List.copyOf(trackedMissiles);
     }
 
     private boolean isValidThreat(VirtualMissile missile) {
@@ -116,7 +115,7 @@ public class TileFireControlRadar extends GenericTile {
 	searchPos = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
     }
 
-    public void tickServer(ComponentTickable tickable) {
+	public synchronized void tickServer(ComponentTickable tickable) {
 	ComponentElectrodynamic electro = getComponent(IComponentType.Electrodynamic);
 
 	running.setValue(electro.getJoulesStored() > BallistixConfig.INSTANCE.RADAR_USAGE.get() / 20.0
@@ -192,7 +191,8 @@ public class TileFireControlRadar extends GenericTile {
     }
 
     @Nullable
-    public VirtualMissile getTargetFor(BlockPos requesterBlockPos, Vec3 requesterPos, float interceptorSpeed) {
+	public synchronized VirtualMissile getTargetFor(BlockPos requesterBlockPos, Vec3 requesterPos,
+	    float interceptorSpeed) {
 
 	UUID currentAssignment = assignments.get(requesterBlockPos);
 

--- a/src/main/java/ballistix/common/tile/radar/TileSearchRadar.java
+++ b/src/main/java/ballistix/common/tile/radar/TileSearchRadar.java
@@ -2,6 +2,8 @@ package ballistix.common.tile.radar;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import ballistix.Ballistix;
 import ballistix.api.missile.MissileManager;
@@ -56,9 +58,9 @@ public class TileSearchRadar extends GenericTile {
 	    new SingleProperty<>(PropertyTypes.BOOLEAN, "isrunning", false));
 
     private final AABB searchArea = new AABB(getBlockPos()).inflate(BallistixConfig.INSTANCE.RADAR_RANGE.get());
-    private final HashSet<VirtualMissile> trackedMissiles = new HashSet<>();
-    public final HashSet<TileESMTower> trackedEsmTowers = new HashSet<>();
-    public final HashSet<IDetected.Detected> detections = new HashSet<>();
+    private final Set<VirtualMissile> trackedMissiles = ConcurrentHashMap.newKeySet();
+    public volatile Set<TileESMTower> trackedEsmTowers = Set.of();
+    public volatile Set<IDetected.Detected> detections = Set.of();
 
     public double clientRotation;
     public double clientRotationSpeed;
@@ -82,7 +84,7 @@ public class TileSearchRadar extends GenericTile {
 		&& level.getBrightness(LightLayer.SKY, getBlockPos()) > 0);
 
 	trackedMissiles.clear();
-	trackedEsmTowers.clear();
+	trackedEsmTowers = Set.of();
 
 	if (!isRunning.getValue()) {
 	    if (redstone.getValue()) {
@@ -106,34 +108,38 @@ public class TileSearchRadar extends GenericTile {
 	    }
 	}
 
-	for (TileESMTower tower : TileESMTower.ESM_TOWERS.getOrDefault(level.dimension(), new HashSet<>())) {
+	HashSet<TileESMTower> nextTrackedEsmTowers = new HashSet<>();
+	for (TileESMTower tower : TileESMTower.ESM_TOWERS.getOrDefault(level.dimension(), Set.of())) {
 	    if (new AABB(tower.getBlockPos()).intersects(searchArea)) {
-		trackedEsmTowers.add(tower);
+		nextTrackedEsmTowers.add(tower);
 	    }
 	}
+	trackedEsmTowers = Set.copyOf(nextTrackedEsmTowers);
 
-	if (trackedMissiles.isEmpty() && trackedEsmTowers.isEmpty() && redstone.getValue()) {
+	boolean hasTrackedEsmTowers = !nextTrackedEsmTowers.isEmpty();
+	if (trackedMissiles.isEmpty() && !hasTrackedEsmTowers && redstone.getValue()) {
 	    redstone.setValue(false);
 	    level.updateNeighborsAt(worldPosition, getBlockState().getBlock());
-	} else if ((!trackedMissiles.isEmpty() || !trackedEsmTowers.isEmpty()) && !redstone.getValue()) {
+	} else if ((!trackedMissiles.isEmpty() || hasTrackedEsmTowers) && !redstone.getValue()) {
 	    redstone.setValue(true);
 	    level.updateNeighborsAt(worldPosition, getBlockState().getBlock());
 	}
 
-	detections.clear();
+	HashSet<IDetected.Detected> nextDetections = new HashSet<>();
 
 	for (VirtualMissile missile : trackedMissiles) {
-	    detections.add(new IDetected.Detected(missile.position,
+	    nextDetections.add(new IDetected.Detected(missile.position,
 		    BallistixItems.ITEMS_MISSILE.getValue(SubtypeMissile
 			    .values()[missile.payloadData.missileType < 1 ? 0 : missile.payloadData.missileType - 1]),
 		    true));
 	}
 
-	for (TileESMTower tile : trackedEsmTowers) {
-	    detections.add(new IDetected.Detected(
+	for (TileESMTower tile : nextTrackedEsmTowers) {
+	    nextDetections.add(new IDetected.Detected(
 		    new Vec3(tile.getBlockPos().getX(), tile.getBlockPos().getY(), tile.getBlockPos().getZ()),
 		    BallistixItems.ITEMS_BALLISTIXMACHINE.getValue(SubtypeBallistixMachine.esmtower), false));
 	}
+	detections = Set.copyOf(nextDetections);
 
     }
 
@@ -155,9 +161,10 @@ public class TileSearchRadar extends GenericTile {
 
     @Override
     public int getComparatorSignal() {
-	if (!trackedMissiles.isEmpty() && !trackedEsmTowers.isEmpty()) {
+	boolean hasTrackedEsmTowers = !trackedEsmTowers.isEmpty();
+	if (!trackedMissiles.isEmpty() && hasTrackedEsmTowers) {
 	    return 15;
-	} else if (trackedMissiles.isEmpty() && !trackedEsmTowers.isEmpty()) {
+	} else if (trackedMissiles.isEmpty() && hasTrackedEsmTowers) {
 	    return 8;
 	} else {
 	    return 0;

--- a/src/main/java/ballistix/common/tile/silo/TileLauncherPlatformT1.java
+++ b/src/main/java/ballistix/common/tile/silo/TileLauncherPlatformT1.java
@@ -1,5 +1,7 @@
 package ballistix.common.tile.silo;
 
+import java.util.Set;
+
 import org.jetbrains.annotations.Nullable;
 
 import ballistix.api.blast.IBlast;
@@ -152,12 +154,13 @@ public class TileLauncherPlatformT1 extends GenericTile implements ILauncherPlat
 	    // launch and blow up stuff on accident!
 
 	    if (level.getBlockEntity(controlPanel.getTarget()) instanceof TileSearchRadar radar) {
+		Set<TileESMTower> trackedTowers = radar.trackedEsmTowers;
 
 		if (TileTurretAntimissile.getDistanceToPos(getBlockPos(),
 			radar.getBlockPos()) <= BallistixConfig.INSTANCE.MAX_DISTANCE_FROM_RADAR.get()
-			&& redstoneTriggered && !radar.trackedEsmTowers.isEmpty()) {
+			&& redstoneTriggered && !trackedTowers.isEmpty()) {
 
-		    for (TileESMTower tower : radar.trackedEsmTowers) {
+		    for (TileESMTower tower : trackedTowers) {
 
 			if (tower != null && !tower.isRemoved()
 				&& launchMissile(tower.getBlockPos(), controlPanel.getFrequency())) {

--- a/src/main/java/ballistix/common/world/TrackerSecurityData.java
+++ b/src/main/java/ballistix/common/world/TrackerSecurityData.java
@@ -1,8 +1,8 @@
 package ballistix.common.world;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -17,7 +17,7 @@ public class TrackerSecurityData extends SavedData {
 
     private static final String DATA_NAME = "ballistix_tracker_security";
 
-    private final HashMap<UUID, Long> revisions = new HashMap<>();
+	private final ConcurrentHashMap<UUID, Long> revisions = new ConcurrentHashMap<>();
 
     public static TrackerSecurityData load(CompoundTag tag, HolderLookup.Provider registries) {
 
@@ -65,9 +65,7 @@ public class TrackerSecurityData extends SavedData {
 
     public long incrementRevision(UUID uuid) {
 
-	long revision = getRevision(uuid) + 1L;
-
-	revisions.put(uuid, revision);
+	long revision = revisions.merge(uuid, 1L, Long::sum);
 	setDirty();
 
 	return revision;

--- a/src/main/java/ballistix/compatibility/TessellateCompat.java
+++ b/src/main/java/ballistix/compatibility/TessellateCompat.java
@@ -1,0 +1,60 @@
+package ballistix.compatibility;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+
+public final class TessellateCompat {
+
+    private static final Method EXECUTE_ON_REGION = load();
+    private static final Method EXECUTE_ON_MAIN = load("executeOnMainThread", Runnable.class);
+
+    private TessellateCompat() {
+    }
+
+    public static boolean isLoaded() {
+	return EXECUTE_ON_REGION != null;
+    }
+
+    public static void runOnRegion(ServerLevel level, BlockPos pos, Runnable work) {
+	if (EXECUTE_ON_REGION == null) {
+	    work.run();
+	    return;
+	}
+	try {
+	    EXECUTE_ON_REGION.invoke(null, level, pos.immutable(), work);
+	} catch (IllegalAccessException e) {
+	    throw new IllegalStateException("Cannot access Tessellate compatibility API", e);
+	} catch (InvocationTargetException e) {
+	    throw new IllegalStateException("Tessellate region dispatch failed", e.getCause());
+	}
+    }
+
+    public static void runOnMain(Runnable work) {
+	if (EXECUTE_ON_MAIN == null) {
+	    work.run();
+	    return;
+	}
+	try {
+	    EXECUTE_ON_MAIN.invoke(null, work);
+	} catch (IllegalAccessException e) {
+	    throw new IllegalStateException("Cannot access Tessellate compatibility API", e);
+	} catch (InvocationTargetException e) {
+	    throw new IllegalStateException("Tessellate main-thread dispatch failed", e.getCause());
+	}
+    }
+
+    private static Method load() {
+	return load("executeOnRegion", ServerLevel.class, BlockPos.class, Runnable.class);
+    }
+
+    private static Method load(String name, Class<?>... parameters) {
+	try {
+	    return Class.forName("org.texboobcat.tessellate.api.TessellateApi").getMethod(name, parameters);
+	} catch (ClassNotFoundException | NoSuchMethodException ignored) {
+	    return null;
+	}
+    }
+}

--- a/src/main/java/ballistix/registers/BallistixAttachmentTypes.java
+++ b/src/main/java/ballistix/registers/BallistixAttachmentTypes.java
@@ -1,9 +1,9 @@
 package ballistix.registers;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -31,13 +31,13 @@ public class BallistixAttachmentTypes {
     public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister
 	    .create(NeoForgeRegistries.ATTACHMENT_TYPES, Ballistix.ID);
 
-    public static final DeferredHolder<AttachmentType<?>, AttachmentType<HashMap<Integer, HashSet<BlockPos>>>> SILO_FREQUENCIES = ATTACHMENT_TYPES
-	    .register("silofrequencies", () -> AttachmentType.builder(() -> new HashMap<Integer, HashSet<BlockPos>>())
-		    .serialize(new IAttachmentSerializer<CompoundTag, HashMap<Integer, HashSet<BlockPos>>>() {
+	public static final DeferredHolder<AttachmentType<?>, AttachmentType<ConcurrentHashMap<Integer, Set<BlockPos>>>> SILO_FREQUENCIES = ATTACHMENT_TYPES
+	    .register("silofrequencies", () -> AttachmentType.builder(() -> new ConcurrentHashMap<Integer, Set<BlockPos>>())
+		    .serialize(new IAttachmentSerializer<CompoundTag, ConcurrentHashMap<Integer, Set<BlockPos>>>() {
 			@Override
-			public HashMap<Integer, HashSet<BlockPos>> read(IAttachmentHolder holder, CompoundTag tag,
+			public ConcurrentHashMap<Integer, Set<BlockPos>> read(IAttachmentHolder holder, CompoundTag tag,
 				HolderLookup.Provider provider) {
-			    HashMap<Integer, HashSet<BlockPos>> data = new HashMap<>();
+			    ConcurrentHashMap<Integer, Set<BlockPos>> data = new ConcurrentHashMap<>();
 
 			    int size = tag.getInt("size");
 			    for (int i = 0; i < size; i++) {
@@ -48,7 +48,7 @@ public class BallistixAttachmentTypes {
 
 				int setSize = stored.getInt("setsize");
 
-				HashSet<BlockPos> tiles = new HashSet<>();
+				Set<BlockPos> tiles = ConcurrentHashMap.newKeySet();
 
 				for (int j = 0; j < setSize; j++) {
 				    BlockPos.CODEC.decode(NbtOps.INSTANCE, stored.get("pos" + j))
@@ -62,19 +62,19 @@ public class BallistixAttachmentTypes {
 			}
 
 			@Override
-			public @Nullable CompoundTag write(HashMap<Integer, HashSet<BlockPos>> attachment,
+			public @Nullable CompoundTag write(ConcurrentHashMap<Integer, Set<BlockPos>> attachment,
 				HolderLookup.Provider provider) {
 			    CompoundTag data = new CompoundTag();
 			    int size = attachment.size();
 			    data.putInt("size", size);
 			    int i = 0;
-			    for (Map.Entry<Integer, HashSet<BlockPos>> entry : attachment.entrySet()) {
+			    for (Map.Entry<Integer, Set<BlockPos>> entry : attachment.entrySet()) {
 
 				CompoundTag store = new CompoundTag();
 
 				store.putInt("freq", entry.getKey());
 
-				HashSet<BlockPos> tiles = entry.getValue();
+				Set<BlockPos> tiles = entry.getValue();
 
 				store.putInt("setsize", tiles.size());
 
@@ -97,18 +97,18 @@ public class BallistixAttachmentTypes {
 			}
 		    }).build());
 
-    public static final DeferredHolder<AttachmentType<?>, AttachmentType<HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>>>> ACTIVE_MISSILES = ATTACHMENT_TYPES
+	public static final DeferredHolder<AttachmentType<?>, AttachmentType<ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>>>> ACTIVE_MISSILES = ATTACHMENT_TYPES
 	    .register("activemissiles", () -> AttachmentType
-		    .builder(() -> new HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>>()).serialize(
-			    new IAttachmentSerializer<CompoundTag, HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>>>() {
+		    .builder(() -> new ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>>()).serialize(
+			    new IAttachmentSerializer<CompoundTag, ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>>>() {
 
 				private static final Codec<ResourceKey<Level>> CODEC = ResourceKey
 					.codec(Registries.DIMENSION);
 
 				@Override
-				public HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> read(
+				public ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>> read(
 					IAttachmentHolder holder, CompoundTag tag, HolderLookup.Provider provider) {
-				    HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> data = new HashMap<>();
+				    ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>> data = new ConcurrentHashMap<>();
 
 				    int size = tag.getInt("size");
 
@@ -123,7 +123,7 @@ public class BallistixAttachmentTypes {
 					ResourceKey<Level> key = CODEC.decode(NbtOps.INSTANCE, stored.get("key"))
 						.getOrThrow().getFirst();
 
-					HashMap<UUID, VirtualMissile> active = new HashMap<>();
+					ConcurrentHashMap<UUID, VirtualMissile> active = new ConcurrentHashMap<>();
 
 					int activeSize = stored.getInt("size");
 
@@ -145,7 +145,7 @@ public class BallistixAttachmentTypes {
 
 				@Override
 				public @Nullable CompoundTag write(
-					HashMap<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> attachment,
+					ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>> attachment,
 					HolderLookup.Provider provider) {
 
 				    CompoundTag data = new CompoundTag();
@@ -154,7 +154,7 @@ public class BallistixAttachmentTypes {
 
 				    int i = 0;
 
-				    for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualMissile>> entry : attachment
+				    for (Map.Entry<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualMissile>> entry : attachment
 					    .entrySet()) {
 
 					if (entry.getValue().size() <= 0) {
@@ -195,19 +195,19 @@ public class BallistixAttachmentTypes {
 			    })
 		    .build());
 
-    public static final DeferredHolder<AttachmentType<?>, AttachmentType<HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>>>> ACTIVE_BULLETS = ATTACHMENT_TYPES
+	public static final DeferredHolder<AttachmentType<?>, AttachmentType<ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>>>> ACTIVE_BULLETS = ATTACHMENT_TYPES
 	    .register("activebullets", () -> AttachmentType
-		    .builder(() -> new HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>>())
+		    .builder(() -> new ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>>())
 		    .serialize(
-			    new IAttachmentSerializer<CompoundTag, HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>>>() {
+			    new IAttachmentSerializer<CompoundTag, ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>>>() {
 
 				private static final Codec<ResourceKey<Level>> CODEC = ResourceKey
 					.codec(Registries.DIMENSION);
 
 				@Override
-				public HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> read(
+				public ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>> read(
 					IAttachmentHolder holder, CompoundTag tag, HolderLookup.Provider provider) {
-				    HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> data = new HashMap<>();
+				    ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>> data = new ConcurrentHashMap<>();
 
 				    int size = tag.getInt("size");
 
@@ -222,7 +222,7 @@ public class BallistixAttachmentTypes {
 					ResourceKey<Level> key = CODEC.decode(NbtOps.INSTANCE, stored.get("key"))
 						.getOrThrow().getFirst();
 
-					HashMap<UUID, VirtualProjectile.VirtualBullet> active = new HashMap<>();
+					ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet> active = new ConcurrentHashMap<>();
 
 					int activeSize = stored.getInt("size");
 
@@ -244,7 +244,7 @@ public class BallistixAttachmentTypes {
 
 				@Override
 				public @Nullable CompoundTag write(
-					HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> attachment,
+					ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>> attachment,
 					HolderLookup.Provider provider) {
 
 				    CompoundTag data = new CompoundTag();
@@ -253,7 +253,7 @@ public class BallistixAttachmentTypes {
 
 				    int i = 0;
 
-				    for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualBullet>> entry : attachment
+				    for (Map.Entry<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualBullet>> entry : attachment
 					    .entrySet()) {
 
 					if (entry.getValue().size() <= 0) {
@@ -294,19 +294,19 @@ public class BallistixAttachmentTypes {
 			    })
 		    .build());
 
-    public static final DeferredHolder<AttachmentType<?>, AttachmentType<HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>>>> ACTIVE_RAILGUNROUNDS = ATTACHMENT_TYPES
+	public static final DeferredHolder<AttachmentType<?>, AttachmentType<ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>>>> ACTIVE_RAILGUNROUNDS = ATTACHMENT_TYPES
 	    .register("activerailgunrounds", () -> AttachmentType.builder(
-		    () -> new HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>>())
+		    () -> new ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>>())
 		    .serialize(
-			    new IAttachmentSerializer<CompoundTag, HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>>>() {
+			    new IAttachmentSerializer<CompoundTag, ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>>>() {
 
 				private static final Codec<ResourceKey<Level>> CODEC = ResourceKey
 					.codec(Registries.DIMENSION);
 
 				@Override
-				public HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> read(
+				public ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>> read(
 					IAttachmentHolder holder, CompoundTag tag, HolderLookup.Provider provider) {
-				    HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> data = new HashMap<>();
+				    ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>> data = new ConcurrentHashMap<>();
 
 				    int size = tag.getInt("size");
 
@@ -321,7 +321,7 @@ public class BallistixAttachmentTypes {
 					ResourceKey<Level> key = CODEC.decode(NbtOps.INSTANCE, stored.get("key"))
 						.getOrThrow().getFirst();
 
-					HashMap<UUID, VirtualProjectile.VirtualRailgunRound> active = new HashMap<>();
+					ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound> active = new ConcurrentHashMap<>();
 
 					int activeSize = stored.getInt("size");
 
@@ -343,7 +343,7 @@ public class BallistixAttachmentTypes {
 
 				@Override
 				public @Nullable CompoundTag write(
-					HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> attachment,
+					ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>> attachment,
 					HolderLookup.Provider provider) {
 
 				    CompoundTag data = new CompoundTag();
@@ -352,7 +352,7 @@ public class BallistixAttachmentTypes {
 
 				    int i = 0;
 
-				    for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualRailgunRound>> entry : attachment
+				    for (Map.Entry<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualRailgunRound>> entry : attachment
 					    .entrySet()) {
 
 					if (entry.getValue().size() <= 0) {
@@ -395,19 +395,19 @@ public class BallistixAttachmentTypes {
 			    })
 		    .build());
 
-    public static final DeferredHolder<AttachmentType<?>, AttachmentType<HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>>>> ACTIVE_SAMS = ATTACHMENT_TYPES
+	public static final DeferredHolder<AttachmentType<?>, AttachmentType<ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>>>> ACTIVE_SAMS = ATTACHMENT_TYPES
 	    .register("activesams", () -> AttachmentType
-		    .builder(() -> new HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>>())
+		    .builder(() -> new ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>>())
 		    .serialize(
-			    new IAttachmentSerializer<CompoundTag, HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>>>() {
+			    new IAttachmentSerializer<CompoundTag, ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>>>() {
 
 				private static final Codec<ResourceKey<Level>> CODEC = ResourceKey
 					.codec(Registries.DIMENSION);
 
 				@Override
-				public HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> read(
+				public ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>> read(
 					IAttachmentHolder holder, CompoundTag tag, HolderLookup.Provider provider) {
-				    HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> data = new HashMap<>();
+				    ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>> data = new ConcurrentHashMap<>();
 
 				    int size = tag.getInt("size");
 
@@ -422,7 +422,7 @@ public class BallistixAttachmentTypes {
 					ResourceKey<Level> key = CODEC.decode(NbtOps.INSTANCE, stored.get("key"))
 						.getOrThrow().getFirst();
 
-					HashMap<UUID, VirtualProjectile.VirtualSAM> active = new HashMap<>();
+					ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM> active = new ConcurrentHashMap<>();
 
 					int activeSize = stored.getInt("size");
 
@@ -444,7 +444,7 @@ public class BallistixAttachmentTypes {
 
 				@Override
 				public @Nullable CompoundTag write(
-					HashMap<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> attachment,
+					ConcurrentHashMap<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>> attachment,
 					HolderLookup.Provider provider) {
 
 				    CompoundTag data = new CompoundTag();
@@ -453,7 +453,7 @@ public class BallistixAttachmentTypes {
 
 				    int i = 0;
 
-				    for (Map.Entry<ResourceKey<Level>, HashMap<UUID, VirtualProjectile.VirtualSAM>> entry : attachment
+				    for (Map.Entry<ResourceKey<Level>, ConcurrentHashMap<UUID, VirtualProjectile.VirtualSAM>> entry : attachment
 					    .entrySet()) {
 
 					if (entry.getValue().size() <= 0) {


### PR DESCRIPTION
This adds optional compatibility with Tessellate's region-threaded server model. Missile and projectile updates are now dispatched to the correct region, duplicate ticks are prevented when projectiles cross chunk boundaries, and entity spawn state is safely shared between region and main threads.

It also updates blast processing, silo registration, laser designator launches, radar tracking, and attachment data to support concurrent access safely. Tessellate remains optional.